### PR TITLE
Updated OpenAir Spec

### DIFF
--- a/OpenAir_File_Format_Support.md
+++ b/OpenAir_File_Format_Support.md
@@ -113,7 +113,7 @@ AN ED-R6 Brokdorf H24
 
 #### AY: Airspace Type
 
-*Optional.*  Identifies the type of airspace or a special-use airspace. Omit for airspaces without a type. Typically used immediately after the `AC` command.
+Identifies the type of airspace or a special-use airspace. Typically used immediately after the `AC` command.
 
 Format:
 ```
@@ -126,40 +126,42 @@ The `Type` field accepts various categories or functions of the airspace:
 | ------- | ---------------------------------------------------------- |
 | ACCSEC  | Airspace providing communication frequency in remote areas |
 | ADIZ    | Air Defence Ident Zone                                     |
-| ASRA    | Aerial Sporting Or Recreational Activity                   |
 | ALERT   | Alert Area                                                 |
+| ASRA    | Aerial Sporting Or Recreational Activity                   |
+| ATZ     | Aeordrome Traffic Zone                                     |
 | AWY     | Airway                                                     |
 | CTA     | Controlled Traffic Area                                    |
 | CTR     | Control Zone                                               |
-| Q       | Danger Area                                                |
+| CUSTOM  | Custom or user defined airspace                            |
 | FIR     | Flight Information Region                                  |
 | FIS     | Flight Information Service Sector                          |
 | GSEC    | Gliding Sector                                             |
 | HTZ     | Helicopter Traffic Zone                                    |
 | LTA     | Lower Traffic Area (Allows VFR Traffic in CTA)             |
 | MATZ    | Military Airport Traffic Zone                              |
-| MRT     | Military Route                                             |
 | MTA     | Military Training Area                                     |
 | MTR     | Military Training Route                                    |
+| N       | NTOAM Affected Area                                        |
+| NONE    | Airspace without type                                      |
 | OFR     | Overflight Restriction                                     |
 | P       | Prohibited Area                                            |
-| PROT    | Protected Airspace                                         |
+| Q       | Danger Area                                                |
 | R       | Restricted Area                                            |
 | RMZ     | Radio Mandatory Zone                                       |
-| TFR     | TSA/RRA Feeding Route                                      |
+| TFR     | Temporary Flight Restriction                               |
 | TIA     | Traffic Information Area                                   |
 | TIZ     | Traffic Information Zone                                   |
 | TMA     | Terminal Manoeuvring Area                                  |
 | TMZ     | Transponder Mandatory Zone                                 |
 | TRA     | Temporary Reserved Area                                    |
-| TRP     | Transponder Setting                                        |
+| TRAFR   | TRA/TSA Feeding Route                                      |
+| TRZ     | Transponder Recommended Zone                               |
 | TSA     | Temporary Segregated Area                                  |
 | UIR     | Upper Flight Information Region                            |
 | UTA     | Upper Traffic Area (Allows VFR Traffic in CTA)             |
+| VFRR    | Designated Route for VFR                                   |
 | VFRSEC  | Visual Flying Rules Sector                                 |
 | WARNING | Warning Area                                               |
-| GP      | Glider prohibited area                                     |
-| MTMA    | Military Terminal Manouvering Area                         |
 
 Example:
 ```
@@ -210,12 +212,13 @@ AG Nordholz Radar
 
 #### AA: Airspace Activation Times
 
-*Optional.* Use [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) time interval format to express the time when the airspace is active. Only the time interval format is allowed and must be specified in UTC (Zulu) time, no local or time offsets are supproted. `NONE` token can be used to indicate the unspecified start or end time of the airspace activation. In case of `None/None`  this airspace is included in the data but will be shown when the activation time is supplied (e.g. by NOAM).
+*Optional.* Use [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) time interval format to express the time when the airspace is active. Only the time interval format is allowed and must be specified in UTC (Zulu) time, no local or time offsets are supproted. `NONE` token can be used to indicate the unspecified start or end time of the airspace activation. In case of `NONE/NONE`  this airspace is included in the data but will be shown when the activation time is supplied (e.g. by NOAM).
 
 ```
 AA 2023-12-16T12:00Z/2023-12-16T13:00Z 
 AA 2024-12-17T00:00Z/2024-12-17T24:00Z
 AA 2024-12-17T00:00Z/NONE
+AA NONE/2024-12-18T00:00Z
 AA NONE/NONE
 ```
 

--- a/OpenAir_File_Format_Support.md
+++ b/OpenAir_File_Format_Support.md
@@ -37,7 +37,7 @@ Altitude is specified in feet `ft` (recommended) or in meters `m`. Example: `300
 
 ### Distance
 
-Distance is measured in nautical miles `nm` andis implied, meaning it is specified <u>without a unit.</u>  This applies to definitions such as radii, widths and segments, see: [DA](#da:-define-an-arc-between-start-and-end-bearing), [DB](#db:-define-an-arc-between-start-and-end-point), [DY](#dy:-define-an-airway-segment), or [V](#v:-variable-assignment) for more.
+Distance is measured in nautical miles `nm` and is implied, meaning it is specified <u>without a unit.</u>  This applies to definitions such as radii, widths and segments, see: [DA](#da:-define-an-arc-between-start-and-end-bearing), [DB](#db:-define-an-arc-between-start-and-end-point), [DY](#dy:-define-an-airway-segment), or [V](#v:-variable-assignment) for more.
 
 ### Time
 
@@ -212,7 +212,7 @@ AG Nordholz Radar
 
 #### AA: Airspace Activation Times
 
-*Optional.* Use [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) time interval format to express the time when the airspace is active. Only the time interval format is allowed and must be specified in UTC (Zulu) time, no local or time offsets are supproted. `NONE` token can be used to indicate the unspecified start or end time of the airspace activation. In case of `NONE/NONE`  this airspace is included in the data but will be shown when the activation time is supplied (e.g. by NOAM).
+*Optional.* Use [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) time interval format to express the time when the airspace is active. Only the time interval format is allowed and must be specified in UTC (Zulu) time, no local or time offsets are supported. `NONE` token can be used to indicate the unspecified start or end time of the airspace activation. In case of `NONE/NONE`  this airspace is included in the data but will be shown when the activation time is supplied (e.g. by NOAM).
 
 ```
 AA 2023-12-16T12:00Z/2023-12-16T13:00Z 

--- a/OpenAir_File_Format_Support.md
+++ b/OpenAir_File_Format_Support.md
@@ -208,23 +208,23 @@ AG Nordholz Radar
 
 
 
-#### AT: Airspace Activation Times
+#### AA: Airspace Activation Times
 
 *Optional.* Use [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) time interval format to express the time when the airspace is active. Only the time interval format is allowed and must be specified in UTC (Zulu) time, no local or time offsets are supproted. `NONE` token can be used to indicate the unspecified start or end time of the airspace activation. In case of `None/None`  this airspace is included in the data but will be shown when the activation time is supplied (e.g. by NOAM).
 
 ```
-AT 2023-12-16T12:00Z/2023-12-16T13:00Z 
-AT 2024-12-17T00:00Z/2024-12-17T24:00Z
-AT 2024-12-17T00:00Z/NONE
-AT NONE/NONE
+AA 2023-12-16T12:00Z/2023-12-16T13:00Z 
+AA 2024-12-17T00:00Z/2024-12-17T24:00Z
+AA 2024-12-17T00:00Z/NONE
+AA NONE/NONE
 ```
 
-#### TP: Transponder Code
+#### AX: Transponder Code
 
 *Optional* Transponder code to be used with the airspace. Must be a 4 digit code.
 
 ```
-TP 7000
+AX 7000
 ```
 
 

--- a/OpenAir_File_Format_Support.md
+++ b/OpenAir_File_Format_Support.md
@@ -212,13 +212,14 @@ AG Nordholz Radar
 
 #### AA: Airspace Activation Times
 
-*Optional.* Use [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) time interval format to express the time when the airspace is active. Only the time interval format is allowed and must be specified in UTC (Zulu) time, no local or time offsets are supported. `NONE` token can be used to indicate the unspecified start or end time of the airspace activation. In case of `NONE/NONE`  this airspace is included in the data but will be shown when the activation time is supplied (e.g. by NOAM).
+*Optional.* Use [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) time interval format to express the time when the airspace is active. Only the time interval format is allowed and must be specified in UTC (Zulu) time, no local or time offsets are supported. `NONE` token can be used to indicate the unspecified start or end time of the airspace activation. In case of `NONE/NONE`  this airspace is included in the data but will be shown when the activation time is supplied (e.g. by NOTAM) and no other AA commands can be set/all others will be ignored.
 
 ```
 AA 2023-12-16T12:00Z/2023-12-16T13:00Z 
 AA 2024-12-17T00:00Z/2024-12-17T24:00Z
 AA 2024-12-17T00:00Z/NONE
 AA NONE/2024-12-18T00:00Z
+------OR------
 AA NONE/NONE
 ```
 
@@ -243,11 +244,11 @@ AH Altitude AltRef
 ```
 
 Altitude references are `AGL`, `FL`, `STD`, `AMSL` . For an undefined upper limit, use `UNL` without specifying an altitude.
-
+ 
 Example:
 ```
 AH FL145
-AL 1000ft MSL
+AL 1000ft AMSL
 ```
 
 > [!IMPORTANT]
@@ -262,7 +263,7 @@ Format:
 AL Altitude AltRef
 ```
 
-Altitude references are `AGL`, `FL`, `STD`, `MSL`. For areas extending to the ground, use `GND`, omitting the altitude.
+Altitude references are `AGL`, `FL`, `STD`, `AMSL`. For areas extending to the ground, use `GND`, omitting the altitude.
 
 
 Example:

--- a/OpenAir_File_Format_Support.md
+++ b/OpenAir_File_Format_Support.md
@@ -41,7 +41,7 @@ Distance is measured in nautical miles `nm` andis implied, meaning it is specifi
 
 ### Time
 
-Time is specified using the [ISO8061](https://en.wikipedia.org/wiki/ISO_8601) format, use only UTC (Zulu) time.
+Time is specified using the [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) format, use only UTC (Zulu) time.
 
 
 
@@ -210,7 +210,7 @@ AG Nordholz Radar
 
 #### AT: Airspace Activation Times
 
-*Optional.* Use [ISO8061](https://en.wikipedia.org/wiki/ISO_8601) time interval format to express the time when the airspace is active. Only the time interval format is allowed and must be specified in UTC (Zulu) time, no local or time offsets are supproted. `NONE` token can be used to indicate the unspecified start or end time of the airspace activation. In case of `None/None`  this airspace is included in the data but will be shown when the activation time is supplied (e.g. by NOAM).
+*Optional.* Use [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) time interval format to express the time when the airspace is active. Only the time interval format is allowed and must be specified in UTC (Zulu) time, no local or time offsets are supproted. `NONE` token can be used to indicate the unspecified start or end time of the airspace activation. In case of `None/None`  this airspace is included in the data but will be shown when the activation time is supplied (e.g. by NOAM).
 
 ```
 AT 2023-12-16T12:00Z/2023-12-16T13:00Z 

--- a/OpenAir_File_Format_Support.md
+++ b/OpenAir_File_Format_Support.md
@@ -6,7 +6,7 @@ date: 2025-04-04
 
 # SeeYou OpenAir file format specification
 
-*Version 2.0, Copyright © 2024, Naviter d.o.o. All Rights Reserved*
+*Version 2.0, Copyright © 2025, Naviter d.o.o. All Rights Reserved*
 
 The OpenAir format, widely utilized in gliding, paragliding, and hang gliding applications, serves to disseminate airspace information and visualize it on maps. Originally developed by WinPilot in 1998, this format has since been embraced and extended by Naviter. This document outlines the OpenAir format alongside the extensions introduced by Naviter.
 

--- a/OpenAir_File_Format_Support.md
+++ b/OpenAir_File_Format_Support.md
@@ -243,7 +243,7 @@ Format:
 AH Altitude AltRef
 ```
 
-Altitude references are `AGL`, `FL`, `STD`, `AMSL` . For an undefined upper limit, use `UNL` without specifying an altitude.
+Altitude references must be `AGL`, `FL`, `STD`, `AMSL` . For an undefined upper limit, use `UNL` without specifying an altitude.
  
 Example:
 ```

--- a/OpenAir_File_Format_Support.md
+++ b/OpenAir_File_Format_Support.md
@@ -1,12 +1,12 @@
 ---
 title: Extended OpenAir file format specification
-description: SeeYou OpenAir specification with Naviter extensions, Copyright © 2024, Naviter d.o.o. All Rights Reserved
-date: 2024-04-04
+description: SeeYou OpenAir specification with Naviter extensions, Copyright © 2025, Naviter d.o.o. All Rights Reserved
+date: 2025-04-04
 ---
 
-# SeeYou OpenAir file format support
+# SeeYou OpenAir file format specification
 
-*Version 1.0, Copyright © 2024, Naviter d.o.o. All Rights Reserved*
+*Version 2.0, Copyright © 2024, Naviter d.o.o. All Rights Reserved*
 
 The OpenAir format, widely utilized in gliding, paragliding, and hang gliding applications, serves to disseminate airspace information and visualize it on maps. Originally developed by WinPilot in 1998, this format has since been embraced and extended by Naviter. This document outlines the OpenAir format alongside the extensions introduced by Naviter.
 
@@ -29,7 +29,7 @@ Geographic coordinates can be represented in two formats:
 2. **Degrees and Decimal Minutes (DDM) format:**  `DD:MM.mmm[N|S]` for latitude and `DDD:MM.mmm[E|W]` for longitude.
    Example: `45:15.531N`
 
-Use a consistant format for each command or data point, either DMS  `45:40:30N 014:18:20E` or DDM `45:40.500N 014:18.333E`.
+Use a consistent format for each command or data point, either DMS  `45:40:30N 014:18:20E` or DDM `45:40.500N 014:18.333E`.
 
 ### Altitude
 
@@ -37,7 +37,22 @@ Altitude is specified in feet `ft` (recommended) or in meters `m`. Example: `300
 
 ### Distance
 
-Distance is measured in nautical miles `nm` and is implied, meaning it is specified <u>without a unit.</u>  This applies to definitions such as radii, widths and segments, see: [DA](#da:-define-an-arc-between-start-and-end-bearing), [DB](#db:-define-an-arc-between-start-and-end-point), [DY](#dy:-define-an-airway-segment), or [V](#v:-variable-assignment) for more.
+Distance is measured in nautical miles `nm` andis implied, meaning it is specified <u>without a unit.</u>  This applies to definitions such as radii, widths and segments, see: [DA](#da:-define-an-arc-between-start-and-end-bearing), [DB](#db:-define-an-arc-between-start-and-end-point), [DY](#dy:-define-an-airway-segment), or [V](#v:-variable-assignment) for more.
+
+### Time
+
+Time is specified using the [ISO8061](https://en.wikipedia.org/wiki/ISO_8601) format, use only UTC (Zulu) time.
+
+
+
+
+
+## Header
+
+Header **must** contain a comment with the following information:
+
+* OpenAIR Version number: `*VERSION: 2.0`
+* Author (App/Person) of  file: `*WRITTEN_BY: SeeYou`
 
 
 ## Airspace Definition
@@ -62,20 +77,23 @@ AC Class
 
 Class Options:
 
-| Class | Definition       |
-| ----- | ---------------- |
-| A     | Class A Airspace |
-| B     | Class B Airspace |
-| C     | Class C Airspace |
-| D     | Class D Airspace |
-| E     | Class E Airspace |
-| F     | Class F Airspace |
-| G     | Class G Airspace |
+| Class  | Definition       |
+| ------ | ---------------- |
+| A      | Class A Airspace |
+| B      | Class B Airspace |
+| C      | Class C Airspace |
+| D      | Class D Airspace |
+| E      | Class E Airspace |
+| F      | Class F Airspace |
+| G      | Class G Airspace |
+| UNC    | Unclassified     |
 
 Example:
 ```
 AC D
 ```
+
+
 
 #### AN: Airspace Name
 
@@ -95,28 +113,53 @@ AN ED-R6 Brokdorf H24
 
 #### AY: Airspace Type
 
-*Optional.*  Identifies the type of airspace or a special-use airspace. Typically used immediately after the `AC` command.
+*Optional.*  Identifies the type of airspace or a special-use airspace. Omit for airspaces without a type. Typically used immediately after the `AC` command.
 
 Format:
 ```
 AY Type
 ```
 
-The `Type` field accepts various categories or functions of the airspace: 
+The `Type` field accepts various categories or functions of the airspace:
 
-| Type | Description     |
-| ---- | --------------- |
-| AWY  | Airway                             |
-| CTR  | Control Zone                       |
-| GSEC | Glider Sector                      |
-| MTMA | Militaty Terminal Manouvering Area |
-| GP   | Gllider Prohibited Area            |
-| P    | Prohibited Area                    |
-| Q    | Danger Area                        |
-| R    | Restricted Area                    |
-| RMZ  | Radio Mandatory Zone               |
-| TRA  | Temporary Reserved Area            |
-| TMZ  | Transponder Mandatory Zone         |
+| Type    | Description                                                |
+| ------- | ---------------------------------------------------------- |
+| ACCSEC  | Airspace providing communication frequency in remote areas |
+| ADIZ    | Air Defence Ident Zone                                     |
+| ASRA    | Aerial Sporting Or Recreational Activity                   |
+| ALERT   | Alert Area                                                 |
+| AWY     | Airway                                                     |
+| CTA     | Controlled Traffic Area                                    |
+| CTR     | Control Zone                                               |
+| Q       | Danger Area                                                |
+| FIR     | Flight Information Region                                  |
+| FIS     | Flight Information Service Sector                          |
+| GSEC    | Gliding Sector                                             |
+| HTZ     | Helicopter Traffic Zone                                    |
+| LTA     | Lower Traffic Area (Allows VFR Traffic in CTA)             |
+| MATZ    | Military Airport Traffic Zone                              |
+| MRT     | Military Route                                             |
+| MTA     | Military Training Area                                     |
+| MTR     | Military Training Route                                    |
+| OFR     | Overflight Restriction                                     |
+| P       | Prohibited Area                                            |
+| PROT    | Protected Airspace                                         |
+| R       | Restricted Area                                            |
+| RMZ     | Radio Mandatory Zone                                       |
+| TFR     | TSA/RRA Feeding Route                                      |
+| TIA     | Traffic Information Area                                   |
+| TIZ     | Traffic Information Zone                                   |
+| TMA     | Terminal Manoeuvring Area                                  |
+| TMZ     | Transponder Mandatory Zone                                 |
+| TRA     | Temporary Reserved Area                                    |
+| TRP     | Transponder Setting                                        |
+| TSA     | Temporary Segregated Area                                  |
+| UIR     | Upper Flight Information Region                            |
+| UTA     | Upper Traffic Area (Allows VFR Traffic in CTA)             |
+| VFRSEC  | Visual Flying Rules Sector                                 |
+| WARNING | Warning Area                                               |
+| GP      | Glider prohibited area                                     |
+| MTMA    | Military Terminal Manouvering Area                         |
 
 Example:
 ```
@@ -124,9 +167,11 @@ AC E
 AY RMZ
 ```
 
+
+
 #### AF: Airspace Frequency
 
-*Optional.* Communication frequency of ATC station or authority overseeing the airspace - used by glider pilots for contanct.
+*Optional.* Communication frequency of ATC station or authority overseeing the airspace - used by glider pilots for contact.
 
 Format:
 ```
@@ -140,6 +185,8 @@ AY RMZ
 AN RMZ ETMN-GLIDER HX 
 AF 123.300
 ```
+
+
 
 #### AG: Station Name
 
@@ -160,6 +207,27 @@ AG Nordholz Radar
 ```
 
 
+
+#### AT: Airspace Activation Times
+
+*Optional.* Use [ISO8061](https://en.wikipedia.org/wiki/ISO_8601) time interval format to express the time when the airspace is active. Only the time interval format is allowed and must be specified in UTC (Zulu) time, no local or time offsets are supproted. `NONE` token can be used to indicate the unspecified start or end time of the airspace activation. In case of `None/None`  this airspace is included in the data but will be shown when the activation time is supplied (e.g. by NOAM).
+
+```
+AT 2023-12-16T12:00Z/2023-12-16T13:00Z 
+AT 2024-12-17T00:00Z/2024-12-17T24:00Z
+AT 2024-12-17T00:00Z/NONE
+AT NONE/NONE
+```
+
+#### TP: Transponder Code
+
+*Optional* Transponder code to be used with the airspace. Must be a 4 digit code.
+
+```
+TP 7000
+```
+
+
 ### A: Altitude Definitions
 
 #### AH: Upper Alitutde Limit
@@ -171,7 +239,7 @@ Format:
 AH Altitude AltRef
 ```
 
-Altitude references must be `AGL`, `FL`, `STD`, `AMSL` . For an undefined upper limit, use `UNL` without specifying an altitude.
+Altitude references are `AGL`, `FL`, `STD`, `AMSL` . For an undefined upper limit, use `UNL` without specifying an altitude.
 
 Example:
 ```
@@ -180,7 +248,7 @@ AL 1000ft MSL
 ```
 
 > [!IMPORTANT]
-> Each airspace must have only one upper altitude limit. Including multiple altitude references creates ambiguity and is considered invalid (e.g., ~~`100m AGL/423m AMSL`~~ is not permitted).
+> Each airspace definition must include only one upper altitude limit. Including multiple altitude references creates ambiguity and is considered invalid (e.g., ~~`100m AGL/423m AMSL`~~ is not permitted).
 
 #### AL: Lower Alitutde Limit
 
@@ -191,7 +259,7 @@ Format:
 AL Altitude AltRef
 ```
 
-Altitude references must be `AGL`, `FL`, `STD`, `MSL`. For areas extending to the ground, use `GND`, omitting the altitude.
+Altitude references are `AGL`, `FL`, `STD`, `MSL`. For areas extending to the ground, use `GND`, omitting the altitude.
 
 
 Example:
@@ -201,13 +269,13 @@ AL 1000ft AGL
 ```
 
 > [!IMPORTANT]
-> Each airspace must have only one lower altitude limit. Including multiple altitude references creates ambiguity and is considered invalid (e.g., ~~`100m AGL/423m AMSL`~~ is not permitted).
+> Each airspace definition must include only one lower altitude limit. Including multiple altitude references creates ambiguity and is considered invalid (e.g., ~~`100m AGL/423m AMSL`~~ is not permitted).
 
 #### Supported Altitude References
 
 | AltRef | Description                                          |
 | ------ | ---------------------------------------------------- |
-| AGL    | ft Above Ground Level                                |
+| AGL    | Above Ground Level                                   |
 | FL     | Flight Level                                         |
 | STD    | Standard Atmospheric Pressure                        |
 | AMSL   | Above Mean Sea Level                                 |
@@ -221,7 +289,7 @@ Geometric definition commands, often used with variable assignemnt `V`, define a
 
 #### DP: Polygon point
 
-Polygons vertices are defined by a series of lines that start with `DP`. They are expected to be mapped clockwise and closed - last defined point is the same as the first . This is the recommended for outlining airspace geometry.
+Polygon vertices are defined by a series of lines that start with `DP`. They are expected to be mapped clockwise and closed - last defined point is the same as the first . This is the recommended method for outlining airspace geometry.
 
 Format:
 ```
@@ -230,19 +298,19 @@ DP Point
 
 Example: 
 ```
-DP 53:47:06 N 008:21:41 E   
-DP 53:50:58 N 008:55:25 E 
-DP 53:45:08 N 008:57:21 E 
-DP 53:41:10 N 008:23:38 E 
-DP 53:47:06 N 008:21:41 E 
+DP 53:47:06N 008:21:41E   
+DP 53:50:58N 008:55:25E 
+DP 53:45:08N 008:57:21E 
+DP 53:41:10N 008:23:38E 
+DP 53:47:06N 008:21:41E 
 
 or
 
-DP 53:47.100 N 008:21.700 E   
-DP 53:50.960 N 008:55.825 E 
-DP 53:45.800 N 008:57.211 E 
-DP 53:41.755 N 008:23.890 E 
-DP 53:47.100 N 008:21.700 E 
+DP 53:47.100N 008:21.700E   
+DP 53:50.960N 008:55.825E 
+DP 53:45.800N 008:57.211E 
+DP 53:41.755N 008:23.890E 
+DP 53:47.100N 008:21.700E 
 ```
 > [!IMPORTANT]
 > Do not mix DMS and DDM notations. Stick to one definition throughout the file.
@@ -253,7 +321,7 @@ DP 53:47.100 N 008:21.700 E
 >
 > Combining airspace shapes defined with `DA`  arcs with points defined as `DP` can result in inconsistencies in how airspace is displayed. Avoid using `DA` if possible.
 
-Defines an arc between two bearings, with its center set by a [V](#v:-variable-assignment) command before. The direction is clockwise by default, but can be altered with `V`.
+Defines an arc between two bearings, with its center set by a preceding [V](#v:-variable-assignment) command. The direction is clockwise by default, but can be altered with `V`.
 
 Format:
 ```
@@ -270,9 +338,9 @@ DA 10, 270, 290
 
 > [!NOTE]
 >
-> The arc is over-defined with `V` and `DB` sentences. Calculate the center of the arc carefully to avoid inconsistent display across various implementations on client software.
+> The arc is overdefined with `V` and `DB` sentences. Calculate the center of the arc carefully to avoid inconsistent display across various implementations on client software.
 
-Defines an arc between two points, with its center set by a [V](#v:-variable-assignment) command before. The direction is clockwise by default, but can be altered with `V`.
+Defines an arc between two points, with its center set by a preceding [V](#v:-variable-assignment) command. The direction is clockwise by default, but can be altered with `V`.
 
 Format:
 
@@ -302,7 +370,7 @@ AC Q
 AN PARA Ailertchen EDGA
 AH FL100
 AL GND
-V X=50:35:36 N 007:56:42 E
+V X=50:35:36N 007:56:42E
 DC 2.00
 ```
 


### PR DESCRIPTION
Updated the OpenAIR file format specification:

- Added the required header:
  - Version format
  - Author
- Added the unclassified airspace class
- Extended airspace types
- Added airspace activation times command: AA.
- Added command to support airspace transponder codes: AX. Closes #8 
